### PR TITLE
feat: dockerize backend with observability stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,78 @@
 # AI Cover Letter Generator
 
-An intelligent system that generates personalized, professional cover letters based on:
+AI Job Application Copilot that combines a Chrome extension with a backend API to help candidates apply faster with higher-quality, personalized content.
 
-- The user’s CV  
-- Real job descriptions extracted from job sites (LinkedIn, Indeed, etc.)  
-- A customizable prompt template per user  
+## What It Does
 
-The system consists of:
+- Generates personalized cover letters using stored CV data plus the target job description.
+- Creates customized CV outputs for specific jobs and returns both LaTeX source and compiled PDF.
+- Auto-detects job context from LinkedIn job pages in the extension.
+- Generates focused answers for LinkedIn application text fields using your CV and optional job context.
+- Lets users save custom prompts per AI service (cover letter, CV customization, match analysis, textarea answers).
+- Supports BYOK (Bring Your Own Key): users with their own API key bypass default rate limits.
 
-- A **browser extension** (Chrome/Edge) that detects job descriptions automatically.
-- A **backend written in .NET 10**, using modern minimal APIs.
-- An AI integration powered by **Groq LLaMA3-70B** (OpenAI-compatible API).
-- A long-term architecture evolving into **distributed microservices**, including:
-  - gRPC APIs
-  - REST APIs
-  - Message queue (RabbitMQ/Kafka)
-  - Outbox pattern
-  - Background workers
-  - PostgreSQL Database
-  - OpenTelemetry, Prometheus, Grafana
-  - Kubernetes
-  - CI/CD
-  - k6 load testing  
+## Core Product Capabilities
 
-This project is intended as a **full-stack learning system** covering advanced backend engineering patterns used in real companies.
+### 1) CV Ingestion and Reuse
 
----
+- Upload CV as PDF, LaTeX, or plain text.
+- Parse and store CV once, then reuse it across generation flows.
+- Check CV existence and fetch stored CV by ID.
 
-## ⚙️ Technology Stack
+### 2) Cover Letter Generation
 
-### Frontend
-- Chrome Extension (Manifest V3)
-- React (optional)
-- JavaScript/TypeScript
-- Chrome Storage API
-- Fetch API for backend communication
+- Generate from stored CV ID + job description.
+- Generate from direct CV text when no file upload is used.
+- Support idempotency keys for safe retries on expensive POST requests.
 
-### Backend
-- **.NET 10.0**
-- Minimal APIs
-- gRPC (future)
-- Groq LLaMA3 via OpenAI-compatible API
-- Outbox pattern
-- Background workers
-- PostgreSQL (future)
-- Docker / Kubernetes (future)
+### 3) CV Customization with LaTeX Pipeline
 
-### Infrastructure & DevOps
-- Docker
-- Kubernetes (k8s)
-- Kustomize or Helm
-- GitHub Actions CI/CD
-- Prometheus + Grafana dashboards
-- OpenTelemetry (metrics/traces/logs)
-- RabbitMQ or Kafka (microservices communication)
-- k6 for load testing
+- Tailor CV for a target role using AI.
+- Return both editable LaTeX and rendered PDF.
+- Compile raw LaTeX to PDF through a dedicated API endpoint.
 
----
+### 4) Job Match Analysis
 
-## 🎯 Current Phase (Phase 1)
-- Single .NET 10 API  
-- Endpoint: `POST /generate-cover-letter`
-- Inputs: job description, CV text, optional prompt template  
-- Output: generated cover letter  
+- Analyze CV against a job description.
+- Return match-oriented feedback for alignment and gaps.
 
----
+### 5) LinkedIn Textarea Auto-Answer
 
-## 🚀 Getting Started
+- Inject AI assist buttons into LinkedIn application text inputs.
+- Generate answers grounded in CV content and optional job context.
+- Auto-fill generated answers back into the target field.
+
+### 6) User Prompt Personalization
+
+- Save, retrieve, and delete per-user prompts for:
+  - cv-customization
+  - cover-letter
+  - match-analysis
+  - textarea-answer
+- Fall back to defaults when user prompts are not defined.
+
+### 7) BYOK and Smart Rate Limiting
+
+- Without user key: sliding-window limit on expensive AI endpoints.
+- With user key: limiter bypass for higher throughput.
+- Key lifecycle endpoints: save, check (masked), delete.
+
+## API Feature Surface (Current)
+
+- CV: parse file, parse text, customize, compile LaTeX, get by ID, exists check, match analysis.
+- Cover letters: generate from CV ID, generate from direct text.
+- Textarea answers: generate LinkedIn/application answers from CV.
+- Settings: BYOK key management + per-service custom prompts.
+- Prompts: inspect default template set.
+
+## Architecture Notes
+
+- Backend follows layered architecture (Domain, Application, Infrastructure, API).
+- Request flow uses minimal APIs + MediatR pipeline + Result-based HTTP mapping.
+- Error handling is centralized with ProblemDetails responses.
+- Observability includes structured logs and metrics with Prometheus/Grafana/Loki integration.
+
+## Getting Started
 
 ### Quick Setup
 
@@ -76,18 +82,21 @@ cd ai-cover-letter-generator
 bash setup.sh
 ```
 
-The setup script will guide you through configuration. Then:
+Then run the API:
 
 ```bash
 cd src/CoverLetter.Api
 dotnet run
 ```
 
-Open: `http://localhost:5000/scalar/v1`
+API docs are available at:
 
-For detailed instructions, see [SETUP.md](SETUP.md).
+- http://localhost:5012/scalar/v1
+
+For detailed setup, see [SETUP.md](SETUP.md).
 
 ### Prerequisites
+
 - .NET 10 SDK
-- Docker & Docker Compose
-- A Groq API key (free at https://console.groq.com/keys)
+- Docker and Docker Compose
+- Groq API key (for BYOK mode)

--- a/SETUP.md
+++ b/SETUP.md
@@ -9,150 +9,92 @@
 
 ## Quick Setup (Recommended)
 
-For new users, run the automated setup script:
+Run everything in Docker with a single command:
 
 ```bash
 git clone https://github.com/Osama-Elzekred/ai-cover-letter-generator.git
 cd ai-cover-letter-generator
-bash setup.sh
-```
-
-The script will:
-- ✅ Restore .NET dependencies
-- ✅ Prompt for your Groq API key and database password
-- ✅ Configure user secrets
-- ✅ Start PostgreSQL in Docker
-- ✅ Build the LaTeX compiler image
-- ✅ Run database migrations
-
-After setup completes:
-```bash
-cd src/CoverLetter.Api
-dotnet run
-```
-
-Then open: `http://localhost:5000/scalar/v1`
-
----
-
-## Manual Setup (Step-by-Step)
-
-If you prefer to understand each step or need to troubleshoot:
-
-### 1. Clone & Install Dependencies
-
-```bash
-git clone https://github.com/Osama-Elzekred/ai-cover-letter-generator.git
-cd ai-cover-letter-generator
-dotnet restore
-```
-
----
-
-### 2. Set User Secrets for Development
-
-User secrets are stored **outside the repo** and won't be committed.
-
-```bash
-cd src/CoverLetter.Api
-
-# Set database connection string (use your own password)
-dotnet user-secrets set "ConnectionStrings:DefaultConnection" "Host=localhost;Port=5432;Database=coverletter_dev;Username=postgres;Password=postgres"
-
-# Set Groq API Key (get from https://console.groq.com/keys)
-dotnet user-secrets set "Groq:ApiKey" "your-groq-api-key-here"
-```
-
-To verify secrets were stored:
-```bash
-dotnet user-secrets list
-```
-
----
-
-### 3. Start PostgreSQL
-
-```bash
 docker-compose -f docker-compose.dev.yml up -d
 ```
 
-Verify it's running:
-```bash
-docker ps  # Should show coverletter_postgres
-```
+Then:
+1. **Get your Groq API key** from https://console.groq.com/keys
+2. **Save it in the extension** → Settings tab → Groq API Key field
+
+That's it! Everything runs:
+- ✅ Backend API on port 5012
+- ✅ PostgreSQL database
+- ✅ Prometheus (metrics)
+- ✅ Loki (logs)
+- ✅ Grafana (dashboards)
+- ✅ LaTeX compiler (PDF generation)
+
+View the API docs: `http://localhost:5012/scalar/v1`
 
 ---
 
-### 4. Build LaTeX Compiler Image
+## Advanced Setup (Local .NET Development)
 
-The API uses Docker to compile LaTeX → PDF in isolated containers.
+If you want to run the backend directly on your machine (not in Docker):
 
-```bash
-# Build the LaTeX compiler image using docker-compose
-docker-compose -f docker-compose.dev.yml build latex-compiler
-```
+### Prerequisites
+- .NET 10 SDK
+- PostgreSQL running locally or in Docker
 
-**Why:** Sandboxes untrusted LaTeX code with no network, limited resources, and read-only filesystem (same pattern AWS Lambda uses). Each compilation spawns a fresh container and exits immediately.
-
----
-
-### 5. Run Database Migrations
+### Steps
 
 ```bash
+# Clone and restore dependencies
+git clone https://github.com/Osama-Elzekred/ai-cover-letter-generator.git
+cd ai-cover-letter-generator
+dotnet restore
+
+# Set your Groq API key
 cd src/CoverLetter.Api
+dotnet user-secrets set "Groq:ApiKey" "gsk_your_key_here"
+
+# Run migrations
 dotnet ef database update
-```
 
----
-
-### 6. Start the API
-
-```bash
-cd src/CoverLetter.Api
+# Start the API
 dotnet run
 ```
 
-The API will start at `https://localhost:5001` or `http://localhost:5000`
+The API will be at: `http://localhost:5012/scalar/v1`
 
-**View API Docs:** Open your browser at `http://localhost:5000/scalar/v1`
-
----
-
-### 7. Test the API
-
-Use the HTTP test files:
-```bash
-# In VS Code with REST Client extension:
-# Open src/CoverLetter.Api/http-tests/health.http
-# Click "Send Request"
-```
-
-Or use curl:
-```bash
-curl http://localhost:5000/health
-```
+**Note:** You'll still need PostgreSQL running (use `docker-compose -f docker-compose.dev.yml up -d postgres` to start just the database)
 
 ---
 
 ## Configuration Files
 
-| File | Purpose | In Repo? | Notes |
-|------|---------|----------|-------|
-| `docker-compose.dev.yml` | Local Docker setup (Postgres + LaTeX) | ✅ YES | Default password: `postgres` (dev only) |
-| `appsettings.json` | Shared API config with safe defaults | ✅ YES | No secrets, safe to commit |
-| User Secrets | API keys & credentials | ❌ NO | Set via `dotnet user-secrets` or `setup.sh` |
-
-**Note:** Sensitive credentials (Groq API key, custom DB passwords) are stored in user secrets outside the repo.
+| File | Purpose |
+|------|---------|
+| `docker-compose.dev.yml` | Complete local setup (Backend, Postgres, Loki, Prometheus, Grafana, LaTeX) |
+| `appsettings.json` | API configuration (no secrets, safe to commit) |
+| `.env.docker` | Environment variables for docker-compose (git-ignored) |
 
 ---
+
+## Service URLs
+
+When using Docker Compose:
+
+| Service | URL | Purpose |
+|---------|-----|---------|
+| Backend API | http://localhost:5012/scalar/v1 | OpenAPI documentation |
+| Health Check | http://localhost:5012/health | API health status |
+| Prometheus | http://localhost:9090 | Metrics dashboard |
+| Grafana | http://localhost:3000 | Log/metric visualization (admin/admin) |
+| Database | localhost:5432 | PostgreSQL connection |
 
 ## Stopping Services
 
 ```bash
-# Stop PostgreSQL
+# Stop all services
 docker-compose -f docker-compose.dev.yml down
 
-# Remove data (if needed)
+# Stop and remove data
 docker-compose -f docker-compose.dev.yml down -v
 ```
 
@@ -160,27 +102,30 @@ docker-compose -f docker-compose.dev.yml down -v
 
 ## Troubleshooting
 
-### Connection Refused
-- Ensure Docker is running and PostgreSQL container started
-- Check `docker logs coverletter_postgres`
+### Docker Services Not Starting
+```bash
+# Check service status
+docker-compose -f docker-compose.dev.yml ps
 
-### User Secrets Not Found
-- Make sure you ran `dotnet user-secrets set` in `src/CoverLetter.Api` directory
-- Check `dotnet user-secrets list` to verify they're stored
+# View logs
+docker-compose -f docker-compose.dev.yml logs coverletterapi
+```
 
-### Groq API Errors
-- Verify your API key is set: `dotnet user-secrets list | grep Groq`
-- Check your Groq account has remaining API quota
+### Backend Returns 401 Unauthorized
+- Save your Groq API key in the extension → Settings tab
+- Or set `GROQ_API_KEY` environment variable before starting docker-compose
 
-### LaTeX Compilation Fails
-- Ensure Docker is running
-- Verify the image exists: `docker images | grep latexmk-compiler`
-- Rebuild if needed: `docker-compose -f docker-compose.dev.yml build latex-compiler`
+### Database Connection Errors
+- Ensure postgres service is running: `docker ps | grep postgres`
+- Check connection string uses `postgres` (not localhost) when running in Docker
 
----
+### Can't Access API Docs
+- Verify backend is running: `curl http://localhost:5012/health`
+- Check if port 5012 is already in use: `netstat -an | findstr 5012` (Windows)
 
-## Next Steps
+## Architecture & Learning
 
-- Read [ARCHITECTURE.md](docs/ARCHITECTURE.md) to understand the project structure
-- Check [http-tests](src/CoverLetter.Api/http-tests/) for example requests
-- Review [PROJECT-ROADMAP.md](docs/PROJECT-ROADMAP.md) for upcoming phases
+- **[ARCHITECTURE.md](docs/ARCHITECTURE.md)** - Project structure (Onion layers, MediatR, Result<T>)
+- **[PROJECT-ROADMAP.md](docs/PROJECT-ROADMAP.md)** - Upcoming features and phases
+- **[http-tests/](src/CoverLetter.Api/http-tests/)** - Example API requests
+- **[Copilot Instructions](.github/copilot-instructions.md)** - Development guidelines

--- a/dev-services.sh
+++ b/dev-services.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Quick start script for development services
+# Starts: PostgreSQL, Loki, Prometheus, Grafana (but NOT the API)
+# This allows you to run the API locally with `dotnet watch run` for hot-reload
+
+echo "🚀 Starting development services..."
+echo ""
+echo "Services:"
+echo "  • PostgreSQL: localhost:5432"
+echo "  • Grafana: http://localhost:3000 (admin/admin)"
+echo "  • Prometheus: http://localhost:9090"
+echo "  • Loki: http://localhost:3100"
+echo ""
+echo "In another terminal, run:"
+echo "  cd src/CoverLetter.Api && dotnet watch run"
+echo ""
+echo "API will be available at: http://localhost:5012"
+echo "Docs: http://localhost:5012/scalar/v1"
+echo ""
+echo "Press Ctrl+C to stop services"
+echo ""
+
+docker-compose -f docker-compose.dev.yml up postgres loki prometheus grafana

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,6 +28,35 @@ services:
     profiles:
       - tools
 
+  coverletterapi:
+    build:
+      context: .
+      dockerfile: src/CoverLetter.Api/Dockerfile
+    image: coverletterapi:dev
+    container_name: coverletter_api
+    ports:
+      - "5012:5012"
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+      - ASPNETCORE_URLS=http://+:5012
+      - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=coverletter_dev;Username=postgres;Password=postgres
+      - Groq__ApiKey=${GROQ_API_KEY}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+      loki:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5012/health"]
+      interval: 30s
+      timeout: 10s
+      start_period: 5s
+      retries: 3
+    networks:
+      - coverletter_network
+
   prometheus:
     image: prom/prometheus:latest
     container_name: coverletter_prometheus

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -41,6 +41,7 @@ services:
       - ASPNETCORE_URLS=http://+:5012
       - ConnectionStrings__DefaultConnection=Host=postgres;Port=5432;Database=coverletter_dev;Username=postgres;Password=postgres
       - Groq__ApiKey=${GROQ_API_KEY}
+      - Logging__Loki__Uri=http://loki:3100
     depends_on:
       postgres:
         condition: service_healthy

--- a/infrastructure/observability/prometheus/prometheus.yml
+++ b/infrastructure/observability/prometheus/prometheus.yml
@@ -22,6 +22,6 @@ scrape_configs:
 
   - job_name: 'dotnet-api'
     static_configs:
-      - targets: ['host.docker.internal:5012']
+      - targets: ['coverletterapi:5012']
     metrics_path: '/metrics'
     scrape_interval: 5s

--- a/setup.sh
+++ b/setup.sh
@@ -63,6 +63,14 @@ echo ""
 # Go back to root
 cd ../..
 
+# Create .env file for docker-compose
+echo "Creating .env file for Docker..."
+cat > .env << EOF
+GROQ_API_KEY=$GROQ_API_KEY
+EOF
+echo -e "${GREEN}✅ .env file created${NC}"
+echo ""
+
 # Start PostgreSQL
 echo "🐘 Starting PostgreSQL..."
 docker-compose -f docker-compose.dev.yml up -d
@@ -88,5 +96,17 @@ echo -e "${GREEN}======================================"
 echo "  ✅ Setup Complete!"
 echo "======================================${NC}"
 echo ""
-echo "To start the API, run:"
-echo "  cd src/CoverLetter.Api && dotnet run"
+echo "📝 Development Workflow:"
+echo ""
+echo "Option 1: Local Development (Recommended) - Hot Reload"
+echo "  Terminal 1: docker-compose -f docker-compose.dev.yml up postgres loki prometheus grafana"
+echo "  Terminal 2: cd src/CoverLetter.Api && dotnet watch run"
+echo ""
+echo "Option 2: Full Docker Stack"
+echo "  docker-compose -f docker-compose.dev.yml up"
+echo ""
+echo "🔍 Access Points:"
+echo "  • API: http://localhost:5012"
+echo "  • Docs: http://localhost:5012/scalar/v1"
+echo "  • Grafana: http://localhost:3000 (admin/admin)"
+echo ""

--- a/src/CoverLetter.Api/CoverLetter.Api.csproj
+++ b/src/CoverLetter.Api/CoverLetter.Api.csproj
@@ -17,15 +17,6 @@
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Grafana.Loki" Version="8.3.2" />
 
-    <!-- OpenTelemetry -->
-    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Process" Version="0.5.0-beta.5" />
-
     <!-- Prometheus metrics client (backup) -->
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
   </ItemGroup>

--- a/src/CoverLetter.Api/Middleware/GlobalExceptionHandler.cs
+++ b/src/CoverLetter.Api/Middleware/GlobalExceptionHandler.cs
@@ -129,10 +129,20 @@ public sealed class GlobalExceptionHandler(
                 "Upstream Rate Limit",
                 "The AI provider is currently rate-limiting requests. Please retry in a few seconds or configure your own API key for higher limits."),
 
+            ApiException apiEx when apiEx.StatusCode == HttpStatusCode.Forbidden => (
+                HttpStatusCode.BadGateway,
+                "API Authentication Failed",
+                "The API key is invalid, expired, or restricted. Please verify your API key in Settings (BYOK) or contact support."),
+
+            ApiException apiEx when apiEx.StatusCode == HttpStatusCode.Unauthorized => (
+                HttpStatusCode.BadGateway,
+                "API Authentication Failed",
+                "Authentication with the AI provider failed. Please verify your API key in Settings (BYOK) or contact support."),
+
             ApiException apiEx => (
                 HttpStatusCode.BadGateway,
                 "External API Error",
-                $"Error communicating with external service: {apiEx.Message}"),
+                $"Error communicating with external service ({(int)apiEx.StatusCode}): {apiEx.Message}"),
 
             HttpRequestException httpEx => (
                 HttpStatusCode.ServiceUnavailable,

--- a/src/CoverLetter.Api/Program.cs
+++ b/src/CoverLetter.Api/Program.cs
@@ -50,7 +50,7 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .Enrich.With(new TimestampEnricher(observabilitySettings))
     .Enrich.With(new FormattedLogEnricher(observabilitySettings))
     .WriteTo.GrafanaLoki(
-        uri: "http://loki:3100",  // Docker service name for Loki 
+        uri: builder.Configuration["Logging:Loki:Uri"] ?? "http://localhost:3100",
         labels: new[]
         {
             new LokiLabel { Key = "app", Value = "coverletter-api" },

--- a/src/CoverLetter.Api/Program.cs
+++ b/src/CoverLetter.Api/Program.cs
@@ -50,8 +50,7 @@ builder.Host.UseSerilog((context, services, configuration) => configuration
     .Enrich.With(new TimestampEnricher(observabilitySettings))
     .Enrich.With(new FormattedLogEnricher(observabilitySettings))
     .WriteTo.GrafanaLoki(
-        // uri: "http://host.docker.internal:3100", /  / Use host.docker.internal on Windows for Docker networking
-        uri: "http://localhost:3100",  // change it later to host.docker.internal when app running in Docker 
+        uri: "http://loki:3100",  // Docker service name for Loki 
         labels: new[]
         {
             new LokiLabel { Key = "app", Value = "coverletter-api" },

--- a/src/CoverLetter.Api/appsettings.json
+++ b/src/CoverLetter.Api/appsettings.json
@@ -37,5 +37,10 @@
     "LogTimeZoneOffset": "+02:00",
     "MetricsRetention": "5m",
     "LatencyHistogramBuckets": [10, 25, 50, 100, 250, 500, 1000, 2500]
+  },
+  "Logging": {
+    "Loki": {
+      "Uri": "http://localhost:3100"
+    }
   }
 }

--- a/src/CoverLetter.Infrastructure/LlmProviders/Groq/GroqLlmService.cs
+++ b/src/CoverLetter.Infrastructure/LlmProviders/Groq/GroqLlmService.cs
@@ -93,6 +93,25 @@ public sealed class GroqLlmService : ILlmService
           "AI provider rate limit reached. Please retry in a few seconds, or use your own API key in Settings (BYOK) for higher limits.",
           ResultType.TooManyRequests);
     }
+    catch (ApiException ex) when (ex.StatusCode == HttpStatusCode.Unauthorized || ex.StatusCode == HttpStatusCode.Forbidden)
+    {
+      stopwatch.Stop();
+      var keySource = isUserKey ? "your provided API key" : "the default API key";
+      _logger.LogWarning(ex, "Groq API authentication failed (403/401) with {KeySource}. Key: {MaskedKey}",
+        keySource, MaskApiKey(apiKey));
+      return Result.Failure<LlmResponse>(
+          $"Invalid or expired API key: {keySource}. Please verify your API key in Settings (BYOK) is correct, or contact support if using the default key.",
+          ResultType.Forbidden);
+    }
+    catch (ApiException ex)
+    {
+      stopwatch.Stop();
+      _logger.LogError(ex, "Groq API error ({StatusCode}) after {ElapsedMs}ms: {Message}",
+        ex.StatusCode, stopwatch.ElapsedMilliseconds, ex.Message);
+      return Result.Failure<LlmResponse>(
+          $"AI provider error ({(int)ex.StatusCode}). Please try again or use your own API key in Settings (BYOK).",
+          ResultType.Error);
+    }
   }
 
   private static string MaskApiKey(string apiKey)


### PR DESCRIPTION
- Add coverletterapi service to docker-compose.dev.yml
  - Builds from src/CoverLetter.Api/Dockerfile
  - Exposes port 5012
  - Connects to postgres, prometheus, and loki services
  - Includes HTTP healthcheck at /health endpoint
  - Supports Groq API key via GROQ_API_KEY environment variable

- Fix observability configuration for Docker networking
  - Update Loki URI from localhost:3100 to loki:3100 (service name)
  - Update Prometheus scrape target from host.docker.internal:5012 to coverletterapi:5012

- Configure database connection string for Docker environment
  - Use postgres service name instead of localhost
  - Enables proper communication between containers on overlay network

All services now properly collect metrics and logs when running in Docker containers.